### PR TITLE
Use step latents for reference style

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -268,9 +268,9 @@ class StyleAlignedReferenceSampler:
         # Replace first latent with the corresponding reference latent after each step
         def callback(step: int, x0: T, x: T, steps: int):
             preview_callback(step, x0, x, steps)
-            if (step < steps):
-                x[0] = ref_latents[step]
-                x0[0] = ref_latents[step]
+            if (step + 1 < steps):
+                x[0] = ref_latents[step+1]
+                x0[0] = ref_latents[step+1]
 
         # Register shared norms
         share_group_norm = share_norm in ["group", "both"]

--- a/__init__.py
+++ b/__init__.py
@@ -290,13 +290,21 @@ class StyleAlignedReferenceSampler:
                 pooled_output = torch.cat([ref_positive[i][1]['pooled_output'], additional['pooled_output'].repeat([batch_size] 
                     + [1] * len(additional['pooled_output'].shape[1:]))], dim=0)
                 additional['pooled_output'] = pooled_output
-            if 'control' in additional and 'control' in ref_positive[i][1]:
-                # combine control conditioning
-                control_hint = torch.cat([ref_positive[i][1]['control'].cond_hint_original, additional['control'].cond_hint_original.repeat([batch_size] 
-                    + [1] * len(additional['control'].cond_hint_original.shape[1:]))], dim=0)
-                cloned_controlnet = additional['control'].copy()
-                cloned_controlnet.set_cond_hint(control_hint, strength=additional['control'].strength, timestep_percent_range=additional['control'].timestep_percent_range)
-                additional['control'] = cloned_controlnet
+            if 'control' in additional:
+                if 'control' in ref_positive[i][1]:
+                    # combine control conditioning
+                    control_hint = torch.cat([ref_positive[i][1]['control'].cond_hint_original, additional['control'].cond_hint_original.repeat([batch_size] 
+                        + [1] * len(additional['control'].cond_hint_original.shape[1:]))], dim=0)
+                    cloned_controlnet = additional['control'].copy()
+                    cloned_controlnet.set_cond_hint(control_hint, strength=additional['control'].strength, timestep_percent_range=additional['control'].timestep_percent_range)
+                    additional['control'] = cloned_controlnet
+                else:
+                    # add zeros for first in batch
+                    control_hint = torch.cat([torch.zeros_like(additional['control'].cond_hint_original), additional['control'].cond_hint_original.repeat([batch_size] 
+                        + [1] * len(additional['control'].cond_hint_original.shape[1:]))], dim=0)
+                    cloned_controlnet = additional['control'].copy()
+                    cloned_controlnet.set_cond_hint(control_hint, strength=additional['control'].strength, timestep_percent_range=additional['control'].timestep_percent_range)
+                    additional['control'] = cloned_controlnet
             batched_condition.append([batch_with_reference, additional])
 
         disable_pbar = not comfy.utils.PROGRESS_BAR_ENABLED


### PR DESCRIPTION
This is an attempt to solve the problem I identified in:  https://github.com/brianfitzgerald/style_aligned_comfy/issues/5#issuecomment-1875971490

I believe the primary issue with the current implementation was that it doesn't send reference latents for every step. I'm getting much better results with this setup, even when the prompt doesn't capture the style's specifics well (I think the demos in this repo use prompts so aligned with the source style that they give a slightly too optimistic impression of how well the style referencing is actually working).

I'll attach some example workflows in the comments.

Changes
 - added new node that creates the noised latents for the reference image and passes all of the step-aligned latents forward; this replaces having to use a sampler manually with flipped sigmas
 - use this output to replace the reference latent with the correct one after each step, to keep the ref latent from denoising away from its target
 - also adjusted the precision of the `scale` parameter, because I've found that small changes at the `.01` level make all the difference. 
 
 [This is where](https://github.com/google/style-aligned/blob/2d4283a42b656ef0827fae5d5b616d51ba3704f4/inversion.py#L111-L117) they follow the above strategy in the paper's official code, replacing the reference latent at every step during inference rather than relying only on the final noised DDIM inversion for the trajectory. 
 
 I think there are still some challenges in that the noise probably isn't being generated as well with this approach as it is in the paper's implementation, ~plus ComfyUI has the annoying limitation currently that we can't pass a different prompt for different samples in the same pass during sampling~ 
 
 Edit -- I've added a commit that separates the conditioning, which significantly improves the prompt alignment.